### PR TITLE
Add basic React input form

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Projectile Simulation</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^5.0.0"
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,0 +1,7 @@
+.App {
+  padding: 2rem;
+}
+
+form > div {
+  margin-bottom: 1rem;
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import InputForm from './components/InputForm';
+import './App.css';
+
+function App() {
+  const [simulationData, setSimulationData] = useState(null);
+
+  const handleStart = ({ speed, angle }) => {
+    // Placeholder for physics calculations
+    setSimulationData({ speed, angle });
+  };
+
+  return (
+    <div className="App">
+      <h1>Projectile Simulator</h1>
+      <InputForm onStart={handleStart} />
+      {simulationData && (
+        <div data-testid="output">
+          <p>Speed: {simulationData.speed}</p>
+          <p>Angle: {simulationData.angle}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/components/InputForm.jsx
+++ b/frontend/src/components/InputForm.jsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+
+function InputForm({ onStart }) {
+  const [speed, setSpeed] = useState('');
+  const [angle, setAngle] = useState('');
+  const [errors, setErrors] = useState({});
+
+  const validate = () => {
+    const newErrors = {};
+    const speedVal = parseFloat(speed);
+    const angleVal = parseFloat(angle);
+
+    if (isNaN(speedVal) || speedVal <= 0) {
+      newErrors.speed = 'Speed must be greater than 0';
+    }
+    if (isNaN(angleVal) || angleVal < 0 || angleVal > 90) {
+      newErrors.angle = 'Angle must be between 0 and 90';
+    }
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (validate()) {
+      onStart({ speed: parseFloat(speed), angle: parseFloat(angle) });
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div>
+        <label>
+          Speed (m/s):
+          <input
+            type="number"
+            value={speed}
+            onChange={(e) => setSpeed(e.target.value)}
+          />
+        </label>
+        {errors.speed && <span className="error">{errors.speed}</span>}
+      </div>
+      <div>
+        <label>
+          Angle (degrees):
+          <input
+            type="number"
+            value={angle}
+            onChange={(e) => setAngle(e.target.value)}
+          />
+        </label>
+        {errors.angle && <span className="error">{errors.angle}</span>}
+      </div>
+      <button type="submit">Start Simulation</button>
+    </form>
+  );
+}
+
+export default InputForm;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,0 +1,10 @@
+body {
+  font-family: sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+.error {
+  color: red;
+  margin-left: 0.5rem;
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- setup a minimal Vite-based React project in `frontend`
- implement `InputForm` with basic validation and start button
- display user input after starting the simulation

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531ef03cf48325b7f5503465d6c4d3