### PR TITLE
Add basic projectile simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# interview
+# Interview Demo
+
+This repository contains a simple projectile simulation written in vanilla JavaScript. The `src/index.html` file presents controls for speed and angle, and a canvas that displays the resulting trajectory. Use the **Play** button to run a new simulation and **Replay** to redraw the last shot.
+
+Open `src/index.html` in any modern browser to test the app.

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,74 @@
+class App {
+    constructor() {
+        this.speedInput = document.getElementById('speedInput');
+        this.angleInput = document.getElementById('angleInput');
+        this.playBtn = document.getElementById('playBtn');
+        this.replayBtn = document.getElementById('replayBtn');
+        this.canvas = document.getElementById('simCanvas');
+        this.ctx = this.canvas.getContext('2d');
+
+        this.lastShot = null;
+
+        this.playBtn.addEventListener('click', () => this.play());
+        this.replayBtn.addEventListener('click', () => this.replay());
+    }
+
+    getInputs() {
+        return {
+            speed: parseFloat(this.speedInput.value),
+            angle: parseFloat(this.angleInput.value) * Math.PI / 180
+        };
+    }
+
+    computeTrajectory(speed, angle) {
+        const g = 9.81;
+        const dt = 0.02;
+        const points = [];
+        let t = 0;
+        while (true) {
+            const x = speed * Math.cos(angle) * t;
+            const y = speed * Math.sin(angle) * t - 0.5 * g * t * t;
+            if (y < 0) break;
+            points.push({x, y});
+            t += dt;
+        }
+        return points;
+    }
+
+    drawTrajectory(points) {
+        const maxX = points[points.length - 1].x;
+        const maxY = Math.max(...points.map(p => p.y));
+        const w = this.canvas.width;
+        const h = this.canvas.height;
+        const scaleX = w / maxX;
+        const scaleY = h / (maxY * 1.1);
+
+        this.ctx.clearRect(0, 0, w, h);
+        this.ctx.beginPath();
+        this.ctx.moveTo(0, h);
+        points.forEach(p => {
+            const x = p.x * scaleX;
+            const y = h - p.y * scaleY;
+            this.ctx.lineTo(x, y);
+        });
+        this.ctx.strokeStyle = 'blue';
+        this.ctx.lineWidth = 2;
+        this.ctx.stroke();
+    }
+
+    play() {
+        const {speed, angle} = this.getInputs();
+        this.lastShot = {speed, angle};
+        const points = this.computeTrajectory(speed, angle);
+        this.drawTrajectory(points);
+        this.replayBtn.disabled = false;
+    }
+
+    replay() {
+        if (!this.lastShot) return;
+        const points = this.computeTrajectory(this.lastShot.speed, this.lastShot.angle);
+        this.drawTrajectory(points);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => new App());

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projectile Simulator</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div id="app" class="container">
+        <h1>Projectile Simulator</h1>
+        <div class="controls">
+            <label>
+                Speed (m/s):
+                <input type="number" id="speedInput" value="50" min="1" max="200" step="1">
+            </label>
+            <label>
+                Angle (deg):
+                <input type="number" id="angleInput" value="45" min="1" max="89" step="1">
+            </label>
+            <button id="playBtn">Play</button>
+            <button id="replayBtn" disabled>Replay</button>
+        </div>
+        <canvas id="simCanvas" width="600" height="300"></canvas>
+    </div>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,45 @@
+body {
+    font-family: sans-serif;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    background-color: #f7f7f7;
+}
+
+.container {
+    max-width: 800px;
+    width: 95%;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 1rem;
+    background-color: #fff;
+}
+
+.controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1rem;
+    align-items: center;
+}
+
+.controls label {
+    display: flex;
+    flex-direction: column;
+    font-size: 0.9rem;
+}
+
+#simCanvas {
+    width: 100%;
+    border: 1px solid #ddd;
+    background-color: #eef;
+}
+
+@media (max-width: 600px) {
+    .controls {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}


### PR DESCRIPTION
## Summary
- create a simple browser-based projectile simulator
- add responsive styles and a small README

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68531f287950832595033a2192fbef11