### PR TITLE
Add backspin support

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -8,11 +8,11 @@ function App() {
   const [simulationData, setSimulationData] = useState(null);
   const [trajectory, setTrajectory] = useState([]);
 
-  const handleStart = ({ speed, angle }) => {
+  const handleStart = ({ speed, angle, spin }) => {
     const theta = (angle * Math.PI) / 180;
-    const points = simulateFlight(speed, theta);
+    const points = simulateFlight(speed, theta, { spin });
     setTrajectory(points.map(({ x, y }) => ({ x, y })));
-    setSimulationData({ speed, angle });
+    setSimulationData({ speed, angle, spin });
   };
 
   return (
@@ -25,6 +25,7 @@ function App() {
             <div data-testid="output">
               <p>Speed: {simulationData.speed} m/s</p>
               <p>Angle: {simulationData.angle}°</p>
+              <p>Backspin: {simulationData.spin} rpm</p>
               <p style={{ fontSize: '0.95rem', color: '#4a4e69', marginTop: '0.5rem' }}>
                 Distances are shown in <b>yards</b>.
               </p>

--- a/frontend/src/components/InputForm.jsx
+++ b/frontend/src/components/InputForm.jsx
@@ -3,18 +3,23 @@ import React, { useState } from 'react';
 function InputForm({ onStart }) {
   const [speed, setSpeed] = useState('');
   const [angle, setAngle] = useState('');
+  const [spin, setSpin] = useState('');
   const [errors, setErrors] = useState({});
 
   const validate = () => {
     const newErrors = {};
     const speedVal = parseFloat(speed);
     const angleVal = parseFloat(angle);
+    const spinVal = parseFloat(spin);
 
     if (isNaN(speedVal) || speedVal <= 0) {
       newErrors.speed = 'Speed must be greater than 0';
     }
     if (isNaN(angleVal) || angleVal < 0 || angleVal > 90) {
       newErrors.angle = 'Angle must be between 0 and 90';
+    }
+    if (isNaN(spinVal) || spinVal < 0) {
+      newErrors.spin = 'Spin must be 0 or greater';
     }
     setErrors(newErrors);
     return Object.keys(newErrors).length === 0;
@@ -23,7 +28,7 @@ function InputForm({ onStart }) {
   const handleSubmit = (e) => {
     e.preventDefault();
     if (validate()) {
-      onStart({ speed: parseFloat(speed), angle: parseFloat(angle) });
+      onStart({ speed: parseFloat(speed), angle: parseFloat(angle), spin: parseFloat(spin) });
     }
   };
 
@@ -50,6 +55,17 @@ function InputForm({ onStart }) {
           />
         </label>
         {errors.angle && <span className="error">{errors.angle}</span>}
+      </div>
+      <div>
+        <label>
+          Backspin (rpm):
+          <input
+            type="number"
+            value={spin}
+            onChange={(e) => setSpin(e.target.value)}
+          />
+        </label>
+        {errors.spin && <span className="error">{errors.spin}</span>}
       </div>
       <button type="submit">Start Simulation</button>
     </form>

--- a/frontend/src/utils/simulateFlight.js
+++ b/frontend/src/utils/simulateFlight.js
@@ -1,12 +1,18 @@
 export function simulateFlight(v0, theta, options = {}) {
   const dt = options.dt ?? 0.02;
   const g = options.g ?? 9.81;
+  const spin = options.spin ?? 0;
+
+  const vx = v0 * Math.cos(theta);
+  const spinRps = spin / 60;
+  const liftCoeff = 0.0004;
+  const aLift = liftCoeff * spinRps * vx;
 
   const points = [];
   let t = 0;
   while (true) {
-    const x = v0 * Math.cos(theta) * t;
-    const y = v0 * Math.sin(theta) * t - 0.5 * g * t * t;
+    const x = vx * t;
+    const y = v0 * Math.sin(theta) * t + 0.5 * aLift * t * t - 0.5 * g * t * t;
     if (y < 0 && t > 0) break;
     points.push({ x, y });
     t += dt;

--- a/src/app.js
+++ b/src/app.js
@@ -4,6 +4,7 @@ class App {
         this.angleInput = document.getElementById('angleInput');
         this.playBtn = document.getElementById('playBtn');
         this.replayBtn = document.getElementById('replayBtn');
+        this.spinInput = document.getElementById('spinInput');
         this.canvas = document.getElementById('simCanvas');
         this.ctx = this.canvas.getContext('2d');
 
@@ -16,19 +17,24 @@ class App {
     getInputs() {
         return {
             speed: parseFloat(this.speedInput.value),
-            angle: parseFloat(this.angleInput.value) * Math.PI / 180
+            angle: parseFloat(this.angleInput.value) * Math.PI / 180,
+            spin: parseFloat(this.spinInput.value)
         };
     }
 
-    computeTrajectory(speed, angle) {
+    computeTrajectory(speed, angle, spin) {
         const g = 9.81;
         const dt = 0.02;
+        const vx = speed * Math.cos(angle);
+        const spinRps = spin / 60;
+        const liftCoeff = 0.0004;
+        const aLift = liftCoeff * spinRps * vx;
         const points = [];
         let t = 0;
         while (true) {
-            const x = speed * Math.cos(angle) * t;
-            const y = speed * Math.sin(angle) * t - 0.5 * g * t * t;
-            if (y < 0) break;
+            const x = vx * t;
+            const y = speed * Math.sin(angle) * t + 0.5 * aLift * t * t - 0.5 * g * t * t;
+            if (y < 0 && t > 0) break;
             points.push({x, y});
             t += dt;
         }
@@ -57,16 +63,16 @@ class App {
     }
 
     play() {
-        const {speed, angle} = this.getInputs();
-        this.lastShot = {speed, angle};
-        const points = this.computeTrajectory(speed, angle);
+        const {speed, angle, spin} = this.getInputs();
+        this.lastShot = {speed, angle, spin};
+        const points = this.computeTrajectory(speed, angle, spin);
         this.drawTrajectory(points);
         this.replayBtn.disabled = false;
     }
 
     replay() {
         if (!this.lastShot) return;
-        const points = this.computeTrajectory(this.lastShot.speed, this.lastShot.angle);
+        const points = this.computeTrajectory(this.lastShot.speed, this.lastShot.angle, this.lastShot.spin);
         this.drawTrajectory(points);
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -18,6 +18,10 @@
                 Angle (deg):
                 <input type="number" id="angleInput" value="45" min="1" max="89" step="1">
             </label>
+            <label>
+                Backspin (rpm):
+                <input type="number" id="spinInput" value="0" min="0" step="10">
+            </label>
             <button id="playBtn">Play</button>
             <button id="replayBtn" disabled>Replay</button>
         </div>

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 const { simulateFlight } = require('./simulateFlight');
 
 // Example usage
-const data = simulateFlight(20, Math.PI / 4); // 20 m/s at 45 degrees
+const data = simulateFlight(20, Math.PI / 4, { spin: 3000 }); // 20 m/s at 45° with 3000 rpm backspin
 console.log(data);

--- a/src/simulateFlight.js
+++ b/src/simulateFlight.js
@@ -11,12 +11,18 @@
 function simulateFlight(v0, theta, options = {}) {
   const dt = options.dt ?? 0.01;
   const g = options.g ?? 9.81;
+  const spin = options.spin ?? 0;
+
+  const vx = v0 * Math.cos(theta);
+  const spinRps = spin / 60;
+  const liftCoeff = 0.0004;
+  const aLift = liftCoeff * spinRps * vx;
 
   const points = [];
   let t = 0;
   while (true) {
-    const x = v0 * Math.cos(theta) * t;
-    const y = v0 * Math.sin(theta) * t - 0.5 * g * t * t;
+    const x = vx * t;
+    const y = v0 * Math.sin(theta) * t + 0.5 * aLift * t * t - 0.5 * g * t * t;
     points.push({ t, x, y });
     if (y <= 0 && t > 0) {
       break;


### PR DESCRIPTION
## Summary
- accept a backspin input field in the form
- store spin value and display it with results
- adjust projectile calculations to include lift from spin
- update vanilla JS demo and Node script
- add sample spin to node example

## Testing
- `npm run build` in `frontend`
- `node src/index.js | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6853249305fc83258e41c0edb8a00a06